### PR TITLE
adds meta viewport tag for RWD goodness

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset='UTF-8'>
   <title>Your First Pull Request - Showcasing good starter issues</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel='stylesheet' href='assets/css/normalize.css'>
   <link rel='stylesheet' href='assets/css/styles.css'>
   <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
@@ -32,7 +33,7 @@
       <p>
         Your First PR shares starter issues on Twitter, at <a href='https://twitter.com/yourfirstpr'>@yourfirstpr</a>.
         If you know of any projects posting issues ideal for someones first contribution
-        to a project, send us a tweet or create an issue on our 
+        to a project, send us a tweet or create an issue on our
         <a href='https://github.com/yourfirstpr/yourfirstpr.github.io'>GitHub Page</a>.
       </p>
       <p>


### PR DESCRIPTION
Added the meta viewport tag -

<meta name="viewport" content="width=device-width, initial-scale=1.0" />

So that mobile and tablet devices don't treat it as a 'desktop view'.

I might be adding this onto the wrong branch? Let me know.