### PR TITLE
Improve README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 ## Configuring and running Jekyll locally
 
-Install Jekyll from the command line with the command:
-
-```
-gem install jekyll
-```
-
 Clone this repo and go into the folder:
 
 ```
@@ -15,10 +9,16 @@ git clone https://github.com/yourfirstpr/yourfirstpr.github.io.git
 cd yourfirstpr.github.io
 ```
 
+Install the dependencies:
+
+```
+bundle
+```
+
 Run Jekyll by using the following command:
 
 ```
-jekyll serve
+bundle exec jekyll serve
 ```
 
 Your local site is now available at `http://localhost:4000`.
@@ -26,5 +26,5 @@ Your local site is now available at `http://localhost:4000`.
 If you want to use another port you can provide the `-P` option like this:
 
 ```
-jekyll serve -P 4242
+bundle exec jekyll serve -P 4242
 ```


### PR DESCRIPTION
I notice in #22 Gemfile and Gemfile.lock were added to make sure contributors all use the right version of Jekyll. The problem is that the commands given in the README don't actually enforce this at all, because they're run outside of Bundler.

This pull requests changes the instructions in the README to actually use Bundler so the Jekyll verison used will always be correct as was the intention in #22.