### PR TITLE
Better Looking Footer

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -90,7 +90,7 @@ hr {
 footer {
     margin: 0 auto;
     padding: 5px 15px;
-
+    text-align: center;
     background: #9255CC;
     color: #FFF;
     font-size: 1em;


### PR DESCRIPTION
I think the copyrights text must be in the centre of the page. It makes it better looking.

![screenshot from 2018-10-27 12-54-54](https://user-images.githubusercontent.com/29047276/47601014-d6d8b800-d9e7-11e8-8f52-937846ab65cd.png)
