### PR TITLE
Fixed broken link for First Timers Only

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ title: Showcasing good starter issues
       you can get started by reading the following texts on the subject:
       <ul>
         <li><a href='https://the-pastry-box-project.net/charlotte-spencer/2015-september-16'>Lowering the Barriers</a> by <a href='https://twitter.com/charlotteis'>Charlotte Spencer</a></li>
-        <li><a href='https://medium.com/@kentcdodds/first-timers-only-78281ea47455'>First Timers Only</a> by <a href='https://twitter.com/kentcdodds'>Kent C. Dodds</a></li>
+        <li><a href='https://kentcdodds.com/blog/first-timers-only'>First Timers Only</a> by <a href='https://twitter.com/kentcdodds'>Kent C. Dodds</a></li>
       </ul>
     </p>
     <h3>Community</h3>


### PR DESCRIPTION
Issue #235: First Timers Only link broken

The article was moved to the authors own website. The URL was updated.

![image](https://user-images.githubusercontent.com/49599773/66793622-3e736600-eecc-11e9-8411-c59f009975ba.png)

